### PR TITLE
Add correct aubio flag for linking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,14 @@ os:
 #- windows
 cache:
   cargo: true
+addons:
+  apt:
+    packages:
+      - libaubio-dev
+before_install:
+  - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then brew unlink python@2; fi
+  - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then brew update; fi
+  - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then brew install aubio; fi
 script:
 - (cd aubio-sys && cargo test --release)
 - (cd aubio-lib && cargo test --release)

--- a/aubio-lib/Cargo.toml
+++ b/aubio-lib/Cargo.toml
@@ -12,6 +12,9 @@ edition = "2018"
 
 [badges]
 
+[dependencies.aubio-sys]
+version = "0.1.2"
+path = "../aubio-sys"
 
 [build-dependencies.fetch_unroll]
 version = "^0.2"
@@ -28,6 +31,8 @@ with-double = []
 with-fftw3 = ["cmake"]
 nolink-fftw3 = []
 shared-fftw3 = []
+
+build = ["aubio-sys/build"]
 
 [package.metadata.docs.rs]
 features = ["rustdoc"]

--- a/aubio-sys/Cargo.toml
+++ b/aubio-sys/Cargo.toml
@@ -12,6 +12,8 @@ edition = "2018"
 
 [badges]
 
+[build-dependencies.pkg-config]
+version = "^0.3"
 
 [build-dependencies.fetch_unroll]
 version = "^0.2"
@@ -24,6 +26,7 @@ optional = true
 [features]
 generate-bindings = ["bindgen", "fetch_unroll"]
 rustdoc = []
+build = []
 
 [package.metadata.docs.rs]
 features = ["rustdoc"]

--- a/aubio-sys/build.rs
+++ b/aubio-sys/build.rs
@@ -1,3 +1,7 @@
+extern crate pkg_config;
+
+use std::env;
+
 #[cfg(feature = "generate-bindings")]
 mod source {
     pub const URL: &str = "https://github.com/katyo/{package}-rs/releases/download/{package}-{version}/{package}-{version}.tar.gz";
@@ -5,6 +9,21 @@ mod source {
 }
 
 fn main() {
+    let build = env::var("CARGO_FEATURE_BUILD").is_ok();
+    if !build {
+        match pkg_config::Config::new()
+            .atleast_version("0.4.9")
+            .probe("aubio")
+        {
+            Ok(paths) => {
+                for path in paths.include_paths {
+                    println!("{}", path.display());
+                }
+            }
+            Err(_) => (),
+        };
+    }
+
     #[cfg(feature = "generate-bindings")]
     {
         use std::{


### PR DESCRIPTION
Without this, trying to build anything with `aubio-rs` crate as a dep and actually using aubio content yields linking error. This tells the compiler to add the `-L audio` flag to the linking step