### PR TITLE
Add norm and phase for CVec

### DIFF
--- a/aubio-rs/src/vec.rs
+++ b/aubio-rs/src/vec.rs
@@ -149,6 +149,18 @@ impl<'a> CVec<'a> {
         self.cvec.length as usize
     }
 
+    pub fn norm(&self) -> &[f32] {
+        unsafe {
+            std::slice::from_raw_parts(self.cvec.norm, self.size())
+        }
+    }
+
+    pub fn phas(&self) -> &[f32] {
+        unsafe {
+            std::slice::from_raw_parts(self.cvec.phas, self.size())
+        }
+    }
+
     #[cfg(not(feature = "check-size"))]
     #[inline]
     pub(crate) fn check_size(&self, _min_size: usize) -> Status { Ok(()) }


### PR DESCRIPTION
Hi!

That would be nice to be able to access a `CVec`'s `norm` and `phase` without having to manually check the layout of the values in the `fftgrain` :grin: 

Added that. Not sure what the return type should be though, so up for discussion :)