### PR TITLE
Fix python build version to py2

### DIFF
--- a/aubio-lib/build.rs
+++ b/aubio-lib/build.rs
@@ -290,7 +290,7 @@ mod utils {
 
             for task in &["configure", "build", "install"] {
                 run_command(
-                    Command::new("python")
+                    Command::new("python2")
                         .envs(env_vars.clone())
                         .current_dir(src_dir)
                         .arg("waf")


### PR DESCRIPTION
Hi,

I get a lot of these:
```
  File "/home/polochon/Documents/Programming/C/libbliss-project/bliss-rs/target/debug/build/aubio-lib-cafc28f3987ed349/out/source/0.5.0-git1f23a23d/waflib/Scripting.py", line 103
    except Errors.WafError ,e:
                           ^
SyntaxError: invalid syntax
)', /home/polochon/.cargo/git/checkouts/aubio-rs-ffe0d0ff37d67323/712a9aa/aubio-lib/build.rs:195:21
```

It's because this syntax is python2-only; making this explicit would help on some systems (such as archlinux)